### PR TITLE
Add the new config for v1.2.3

### DIFF
--- a/eos/04/docker/config-local-v1.2.3.ini
+++ b/eos/04/docker/config-local-v1.2.3.ini
@@ -66,7 +66,7 @@ http-server-address = 0.0.0.0:8888
 # https-private-key-file =
 
 # Specify the Access-Control-Allow-Origin to be returned on each request. (eosio::http_plugin)
-# access-control-allow-origin =
+# access-control-allow-origin = 
 
 # Specify the Access-Control-Allow-Headers to be returned on each request. (eosio::http_plugin)
 # access-control-allow-headers =
@@ -167,7 +167,7 @@ unlock-timeout = 900
 # plugin =
 plugin = eosio::producer_plugin
 plugin = eosio::chain_api_plugin
-# plugin = eosio::wallet_api_plugin
+#plugin = eosio::wallet_api_plugin
 plugin = eosio::history_api_plugin
 plugin = eosio::http_plugin
 # plugin = eosio::mongo_db_plugin

--- a/eos/04/docker/docker-compose-local-eosio1.2.yaml
+++ b/eos/04/docker/docker-compose-local-eosio1.2.yaml
@@ -16,7 +16,7 @@ services:
 
   keosd:
     image: eosio/eos-dev:latest
-    command: /opt/eosio/bin/keosd --wallet-dir /opt/eosio/bin/data-dir --http-server-address=127.0.0.1:8900
+    command: /opt/eosio/bin/keosd --wallet-dir /opt/eosio/bin/data-dir --http-server-address=127.0.0.1:8900 --http-validate-host=false
     hostname: keosd
     links:
       - nodeosd


### PR DESCRIPTION
在config-local-v1.2.3.ini中做了如下改动：
添加了一条指令：http-validate-host = false
注释了一条指令：# plugin = eosio::wallet_api_plugin (这条指令会导致报错，无法启动nodeosd容器)

在docker-compose-local-eosio1.2.yaml中取消注释并修改了以下一条指令：
- ./config-local-v1.2.3.ini:/opt/eosio/bin/data-dir/config.ini